### PR TITLE
Restore mistakenly deleted change to ConfigurableFirmata.h

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=FirmataWithDeviceFeature
-version=2.9.1
+version=2.9.2
 author=Firmata Developers, Doug Johnson
 maintainer=Doug Johnson <strix@whidbey.com>
 sentence=This library implements the Firmata protocol as a set of plugins that can be used to create applications to remotely interface with an Arduino board.

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -93,6 +93,11 @@
 #define SYSEX_NON_REALTIME      0x7E // MIDI Reserved for non-realtime messages
 #define SYSEX_REALTIME          0x7F // MIDI Reserved for realtime messages
 
+// DeviceFirmata commands
+
+#define DEVICE_QUERY            0x30 // message requesting action from a device driver (DeviceFirmata)
+#define DEVICE_RESPONSE         0x31 // message providing the device driver response (DeviceFirmata)
+
 // these are DEPRECATED to make the naming more consistent
 #define FIRMATA_STRING          0x71 // same as STRING_DATA
 #define SYSEX_I2C_REQUEST       0x76 // same as I2C_REQUEST


### PR DESCRIPTION
**The error:**

In commit 3174fd71688d18ebf42d6d9fa26a1d6c4b2b74c9, there were 4 files that were deleted, and 1 that was changed.  This was not the intention.

_Deleted:_
-   examples/ConfigurableFirmataDeviceDriver/ConfigurableFirmataDeviceDriver.ino
-   examples/ConfigurableFirmataDeviceDriver/SelectedDeviceDrivers.h
-   src/DeviceFirmata.cpp
-   src/DeviceFirmata.h 

_Changed:_
-   src/ConfigurableFirmata.h

**The resolution:**

Commit 50b93a8a1240b2b57f14c9209b058a638e1a2bb8 restored
-   examples/ConfigurableFirmataDeviceDriver/ConfigurableFirmataDeviceDriver.ino
-   examples/ConfigurableFirmataDeviceDriver/SelectedDeviceDrivers.h 

Commit fc267e44e655414224a814a3873e4a96c5a57ad1 restored
-   src/DeviceFirmata.cpp
-   src/DeviceFirmata.h 

Commit 6173b418f6c0933038a195adb34771f8e6b554d5 reimplemented the change to
-   src/ConfigurableFirmata.h

I believe that this completely unwinds the damage from the revert.  The release version is now 2.9.2.  My apologies to anyone affected.
